### PR TITLE
Reviewページが途中から始まってしまうバグ

### DIFF
--- a/src/components/detail/ReviewButton.tsx
+++ b/src/components/detail/ReviewButton.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@chakra-ui/button';
-import { useParams, useHistory } from 'react-router-dom';
+import { useHistory } from 'react-router';
+import { useParams } from 'react-router-dom';
 
 type Path = {
   owner: string;


### PR DESCRIPTION
## 🔨 Details of Changes
<!-- 変更内容について記載する -->
- 詳細画面から、レビューの画面へ遷移する方法を変更
- 詳細画面から、レビューの画面へ行く際にページの上部に移動するような機能を実装
- リロードされるとこなく、ページの上部へ移動できてReact の良さも失われなくて良い！？と思ってます。


## ❗ 確認手順

1. `http://localhost:3000/git-baboo/easy-review/40` にアクセス (詳細が長めのとこであればどこでもOK)
2. ページ下部のReviewボタンをクリック
3. ページが遷移

3のページが遷移した時にページの先頭から始まればOKです！

## 📸 Screenshot
<!-- 必要な場合はスクリーンショットを追加する -->

## ✅ Resolved Issues
<!-- 解決する Issues を記載する -->
- close #79 

## 🤝 Related Issues
<!-- 関連する Issues を記載する -->
- #79 
