### PR TITLE
行番号を押下でテンプレート選択→入力欄の流れを完成させる

### DIFF
--- a/src/components/review/DiffFile.tsx
+++ b/src/components/review/DiffFile.tsx
@@ -1,20 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Button } from '@chakra-ui/button';
 import { PlusSquareIcon } from '@chakra-ui/icons';
-import { Box, Heading, VStack } from '@chakra-ui/layout';
-import {
-  Popover,
-  PopoverArrow,
-  PopoverBody,
-  PopoverCloseButton,
-  PopoverContent,
-  PopoverHeader,
-  PopoverTrigger,
-} from '@chakra-ui/popover';
-import { Portal } from '@chakra-ui/portal';
+import { Box, Heading } from '@chakra-ui/layout';
 import { useMemo } from 'react';
 
 import '@/style/difffile.css';
+import ReviewPopover from '@/components/review/Popover';
 
 const reactDiffView = require('react-diff-view');
 const Diff = reactDiffView.Diff;
@@ -33,31 +23,12 @@ type Props = {
 
 const DiffFile = ({ oldPath, newPath, type, hunks, widgets, addWidget }: Props) => {
   const headerPath = oldPath === newPath ? oldPath : `${oldPath} → ${newPath}`;
-  const ButtonTextList = ['❓ 質問', '✨ 素敵', '🤔 改善'];
 
   const renderGutter = ({ side, renderDefault, inHoverState }: any) =>
     inHoverState && side === 'new' ? (
-      <Popover>
-        <PopoverTrigger>
-          <PlusSquareIcon color="white" bgColor="blue.500" />
-        </PopoverTrigger>
-        <Portal>
-          <PopoverContent>
-            <PopoverArrow />
-            <PopoverHeader>テンプレートを選んでみよう！</PopoverHeader>
-            <PopoverCloseButton />
-            <PopoverBody>
-              <VStack>
-                {ButtonTextList.map((ButtonText, index) => (
-                  <Button key={index} w="100%" colorScheme="teal">
-                    {ButtonText}
-                  </Button>
-                ))}
-              </VStack>
-            </PopoverBody>
-          </PopoverContent>
-        </Portal>
-      </Popover>
+      <ReviewPopover>
+        <PlusSquareIcon color="white" bgColor="blue.500" />
+      </ReviewPopover>
     ) : (
       renderDefault()
     );

--- a/src/components/review/DiffFile.tsx
+++ b/src/components/review/DiffFile.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Button } from '@chakra-ui/button';
 import { PlusSquareIcon } from '@chakra-ui/icons';
 import { Box, Heading } from '@chakra-ui/layout';
 import { useMemo, useState } from 'react';
@@ -29,14 +28,15 @@ const DiffFile = ({ oldPath, newPath, type, hunks, widgets, addWidget }: Props) 
 
   const renderGutter = ({ side, renderDefault, inHoverState }: any) =>
     inHoverState && side === 'new' ? (
-      <ReviewPopover>
+      <ReviewPopover handleClick={handleClick}>
         <PlusSquareIcon boxSize={5} color="white" bgColor="blue.500" />
       </ReviewPopover>
     ) : (
       renderDefault()
     );
 
-  const handleClick = () => {
+  const handleClick = (initText: string) => {
+    console.log(initText);
     const key = tmpKey;
     addWidget(key);
     setTmpKey('');
@@ -52,35 +52,32 @@ const DiffFile = ({ oldPath, newPath, type, hunks, widgets, addWidget }: Props) 
   }, [addWidget]);
 
   return (
-    <>
-      <Box w="full" boxShadow="base" align="start">
-        <Heading p={3} size="xs" bgColor="gray.200">
-          {headerPath}
-        </Heading>
-        <Diff
-          viewType="unified"
-          diffType={type}
-          hunks={hunks}
-          widgets={widgets}
-          renderGutter={renderGutter}
-        >
-          {(hunks: any) =>
-            hunks.map((hunk: any) => [
-              <Decoration key={'deco-' + hunk.content}>
-                <Box bg="blue.300" p={2}>
-                  {'　'}
-                </Box>
-                <Box bg="blue.100" p={2}>
-                  {hunk.content}
-                </Box>
-              </Decoration>,
-              <Hunk key={hunk.content} hunk={hunk} gutterEvents={gutterEvents} />,
-            ])
-          }
-        </Diff>
-      </Box>
-      <Button onClick={handleClick}>debug</Button>
-    </>
+    <Box w="full" boxShadow="base" align="start">
+      <Heading p={3} size="xs" bgColor="gray.200">
+        {headerPath}
+      </Heading>
+      <Diff
+        viewType="unified"
+        diffType={type}
+        hunks={hunks}
+        widgets={widgets}
+        renderGutter={renderGutter}
+      >
+        {(hunks: any) =>
+          hunks.map((hunk: any) => [
+            <Decoration key={'deco-' + hunk.content}>
+              <Box bg="blue.300" p={2}>
+                {'　'}
+              </Box>
+              <Box bg="blue.100" p={2}>
+                {hunk.content}
+              </Box>
+            </Decoration>,
+            <Hunk key={hunk.content} hunk={hunk} gutterEvents={gutterEvents} />,
+          ])
+        }
+      </Diff>
+    </Box>
   );
 };
 

--- a/src/components/review/DiffFile.tsx
+++ b/src/components/review/DiffFile.tsx
@@ -1,10 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { Button } from '@chakra-ui/button';
 import { PlusSquareIcon } from '@chakra-ui/icons';
 import { Box, Heading } from '@chakra-ui/layout';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
+
+import ReviewPopover from '@/components/review/Popover';
 
 import '@/style/difffile.css';
-import ReviewPopover from '@/components/review/Popover';
 
 const reactDiffView = require('react-diff-view');
 const Diff = reactDiffView.Diff;
@@ -23,6 +25,7 @@ type Props = {
 
 const DiffFile = ({ oldPath, newPath, type, hunks, widgets, addWidget }: Props) => {
   const headerPath = oldPath === newPath ? oldPath : `${oldPath} → ${newPath}`;
+  const [tmpKey, setTmpKey] = useState<string>('');
 
   const renderGutter = ({ side, renderDefault, inHoverState }: any) =>
     inHoverState && side === 'new' ? (
@@ -33,42 +36,51 @@ const DiffFile = ({ oldPath, newPath, type, hunks, widgets, addWidget }: Props) 
       renderDefault()
     );
 
+  const handleClick = () => {
+    const key = tmpKey;
+    addWidget(key);
+    setTmpKey('');
+  };
+
   const gutterEvents = useMemo(() => {
     return {
       onClick({ change }: any) {
         const key = getChangeKey(change);
-        addWidget(key);
+        setTmpKey(key);
       },
     };
   }, [addWidget]);
 
   return (
-    <Box w="full" boxShadow="base" align="start">
-      <Heading p={3} size="xs" bgColor="gray.200">
-        {headerPath}
-      </Heading>
-      <Diff
-        viewType="unified"
-        diffType={type}
-        hunks={hunks}
-        widgets={widgets}
-        renderGutter={renderGutter}
-      >
-        {(hunks: any) =>
-          hunks.map((hunk: any) => [
-            <Decoration key={'deco-' + hunk.content}>
-              <Box bg="blue.300" p={2}>
-                {'　'}
-              </Box>
-              <Box bg="blue.100" p={2}>
-                {hunk.content}
-              </Box>
-            </Decoration>,
-            <Hunk key={hunk.content} hunk={hunk} gutterEvents={gutterEvents} />,
-          ])
-        }
-      </Diff>
-    </Box>
+    <>
+      <Box w="full" boxShadow="base" align="start">
+        <Heading p={3} size="xs" bgColor="gray.200">
+          {headerPath}
+        </Heading>
+        <Diff
+          viewType="unified"
+          diffType={type}
+          hunks={hunks}
+          widgets={widgets}
+          renderGutter={renderGutter}
+        >
+          {(hunks: any) =>
+            hunks.map((hunk: any) => [
+              <Decoration key={'deco-' + hunk.content}>
+                <Box bg="blue.300" p={2}>
+                  {'　'}
+                </Box>
+                <Box bg="blue.100" p={2}>
+                  {hunk.content}
+                </Box>
+              </Decoration>,
+              <Hunk key={hunk.content} hunk={hunk} gutterEvents={gutterEvents} />,
+            ])
+          }
+        </Diff>
+      </Box>
+      <Button onClick={handleClick}>debug</Button>
+    </>
   );
 };
 

--- a/src/components/review/DiffFile.tsx
+++ b/src/components/review/DiffFile.tsx
@@ -27,7 +27,7 @@ const DiffFile = ({ oldPath, newPath, type, hunks, widgets, addWidget }: Props) 
   const renderGutter = ({ side, renderDefault, inHoverState }: any) =>
     inHoverState && side === 'new' ? (
       <ReviewPopover>
-        <PlusSquareIcon color="white" bgColor="blue.500" />
+        <PlusSquareIcon boxSize={5} color="white" bgColor="blue.500" />
       </ReviewPopover>
     ) : (
       renderDefault()

--- a/src/components/review/DiffFile.tsx
+++ b/src/components/review/DiffFile.tsx
@@ -38,7 +38,7 @@ const DiffFile = ({ oldPath, newPath, type, hunks, widgets, addWidget }: Props) 
   const handleClick = (initText: string) => {
     console.log(initText);
     const key = tmpKey;
-    addWidget(key);
+    addWidget(key, initText);
     setTmpKey('');
   };
 

--- a/src/components/review/Popover.tsx
+++ b/src/components/review/Popover.tsx
@@ -12,13 +12,41 @@ import {
 } from '@chakra-ui/react';
 import React, { ReactNode } from 'react';
 
-const ButtonTextList = ['❓ 質問', '✨ 素敵', '🤔 改善'];
+const ButtonTextList = [
+  {
+    label: '❓ 質問',
+    initText: `<!--
+できるだけ具体的に質問してみましょう
+例）〜の処理の内容がわからないので教えてください！
+-->
+`,
+  },
+  {
+    label: '✨ 素敵',
+    initText: `<!--
+良いと感じたコードを見つけたら気軽にコメントしましょう！
+例）命名がとてもキレイです 💯
+例）この部分がとても読みやすいです ✨
+-->
+`,
+  },
+  {
+    label: '🤔 改善',
+    initText: ` <!--
+タイポやバグなどを見つけたら早急に報告しましょう！
+例）タイポしてるので修正お願いします！ reveiw > review
+例）ローカルだと以下のようにレイアウトが崩れてしまっているので確認をお願いします！
+-->
+`,
+  },
+];
 
 type Props = {
+  handleClick: (initText: string) => void;
   children: ReactNode;
 };
 
-const ReviewPopover = ({ children }: Props) => {
+const ReviewPopover = ({ handleClick, children }: Props) => {
   return (
     <Popover>
       <PopoverTrigger>{children}</PopoverTrigger>
@@ -30,8 +58,13 @@ const ReviewPopover = ({ children }: Props) => {
           <PopoverBody>
             <VStack>
               {ButtonTextList.map((ButtonText, index) => (
-                <Button key={index} w="100%" colorScheme="teal">
-                  {ButtonText}
+                <Button
+                  key={index}
+                  w="100%"
+                  colorScheme="teal"
+                  onClick={() => handleClick(ButtonText.initText)}
+                >
+                  {ButtonText.label}
                 </Button>
               ))}
             </VStack>

--- a/src/components/review/useWidgets.tsx
+++ b/src/components/review/useWidgets.tsx
@@ -13,7 +13,7 @@ const useWidgets = (reviewer: any) => {
           ...state,
           [action.payload.key]: {
             id: uniqueId('widget-'),
-            draft: '',
+            draft: action.payload.body,
             comments: [],
           },
         };
@@ -47,7 +47,10 @@ const useWidgets = (reviewer: any) => {
     }
   }, {});
 
-  const addWidget = useCallback((key) => dispatch({ type: 'add', payload: { key } }), []);
+  const addWidget = useCallback(
+    (key, body) => dispatch({ type: 'add', payload: { key, body } }),
+    []
+  );
 
   const writeComment = useCallback(
     (key, body) => dispatch({ type: 'input', payload: { key, body } }),

--- a/src/pages/review.tsx
+++ b/src/pages/review.tsx
@@ -2,14 +2,12 @@
 import { Box, Text, Container, HStack, Divider, Center } from '@chakra-ui/layout';
 import { Avatar, Button } from '@chakra-ui/react';
 import React from 'react';
-import { BiCommentAdd } from 'react-icons/bi';
 import { BsFillChatDotsFill } from 'react-icons/bs';
 import { useParams } from 'react-router';
 
 import Layout from '@/components/Layout';
 import TemplateList from '@/components/TemplateList';
 import DiffFiles from '@/components/review/DiffFiles';
-import Popover from '@/components/review/Popover';
 import ReviewTitle from '@/components/review/ReviewTitle';
 import useWidgets from '@/components/review/useWidgets';
 import { dummyDiff as diff } from '@/data/dummyDiff'; // TODO: ダミーデータ入れ換え
@@ -80,11 +78,6 @@ const ReviewPage = () => {
                 widgets={widgets}
                 addWidget={addWidget}
               />
-              <Popover>
-                <Button size="xs" colorScheme="blue">
-                  <BiCommentAdd color="white" size={15} />
-                </Button>
-              </Popover>
               <Button colorScheme="teal" mt={9} size="lg" onClick={handleSubmit}>
                 完了
               </Button>


### PR DESCRIPTION
## 🔨 Details of Changes
<!-- 変更内容について記載する -->
- 行番号のところの「+」ボタンを押すとテンプレートの選択肢が出てくる
- 選択すると、初期値が入力された状態のテキストエリアが出てくる

## 📸 Screenshot
<!-- 必要な場合はスクリーンショットを追加する -->

## ✅ Resolved Issues
<!-- 解決する Issues を記載する -->
- close #73 

## いくらか課題はあり
- 「+」クリック後、真下にカーソル降ろさないとホバー外れやすい
- テキストエリアに初期値入れたから、初期の高さ広めにしたい
- コメントを追加した時、コメントアウトがそのまま表示されてしまう