### PR TITLE
ファイルの差分がリネームのみの場合、その旨を表示させる

### DIFF
--- a/src/components/review/DiffFile.tsx
+++ b/src/components/review/DiffFile.tsx
@@ -1,5 +1,5 @@
 import { PlusSquareIcon } from "@chakra-ui/icons";
-import { Box, Heading } from "@chakra-ui/layout";
+import { Box, Heading, Text } from "@chakra-ui/react";
 import { useMemo, useState } from "react";
 
 import ReviewPopover from "@/components/review/Popover";
@@ -91,27 +91,39 @@ const DiffFile = ({
       <Heading p={3} size="xs" bgColor="gray.200">
         {headerPath}
       </Heading>
-      <Diff
-        viewType="unified"
-        diffType={type}
-        hunks={hunks}
-        widgets={widgets[fileId]}
-        renderGutter={renderGutter}
-      >
-        {(hunks: any) =>
-          hunks.map((hunk: any) => [
-            <Decoration key={"deco-" + hunk.content}>
-              <Box bg="blue.300" p={2}>
-                {"　"}
-              </Box>
-              <Box bg="blue.100" p={2}>
-                {hunk.content}
-              </Box>
-            </Decoration>,
-            <Hunk key={hunk.content} hunk={hunk} gutterEvents={gutterEvents} />,
-          ])
-        }
-      </Diff>
+      {type === "rename" ? (
+        <Text p={2}>
+          ファイル名の変更もしくはファイルの移動が行われました。
+          <br />
+          内容に変更はありません。
+        </Text>
+      ) : (
+        <Diff
+          viewType="unified"
+          diffType={type}
+          hunks={hunks}
+          widgets={widgets[fileId]}
+          renderGutter={renderGutter}
+        >
+          {(hunks: any) =>
+            hunks.map((hunk: any) => [
+              <Decoration key={"deco-" + hunk.content}>
+                <Box bg="blue.300" p={2}>
+                  {"　"}
+                </Box>
+                <Box bg="blue.100" p={2}>
+                  {hunk.content}
+                </Box>
+              </Decoration>,
+              <Hunk
+                key={hunk.content}
+                hunk={hunk}
+                gutterEvents={gutterEvents}
+              />,
+            ])
+          }
+        </Diff>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
## 🔨 Details of Changes
<!-- 変更内容について記載する -->
- ファイルの差分がリネームのみの場合、その旨を表示させる

## 📸 Screenshot
<!-- 必要な場合はスクリーンショットを追加する -->
![Screenshot-20211216002056-730x131](https://user-images.githubusercontent.com/63896499/146213814-15150faf-451f-4f02-b721-ec21101ef839.png)
変更前や本家は #118 を参照

## ✅ Resolved Issues
<!-- 解決する Issues を記載する -->
- close #118 

## 補足

### 表示されるメッセージに関して
とりあえずそれっぽいの書いてみたけど、提案あればぜひお願いします

### レビューしたいけど、ファイル名変更のみの差分を含むプルリクどれやねん
( ´･ω･)⊃ #177 
```
/git-baboo/easy-review/177/review
```