### PR TITLE
差分表示において、バイナリファイルの場合、その旨を表示する

### DIFF
--- a/src/components/review/DiffFile.tsx
+++ b/src/components/review/DiffFile.tsx
@@ -15,6 +15,7 @@ type Props = {
   oldPath: string;
   newPath: string;
   type: string;
+  isBinary: boolean;
   hunks: any;
   widgets: any;
   addWidget: (
@@ -30,6 +31,7 @@ const DiffFile = ({
   oldPath,
   newPath,
   type,
+  isBinary,
   hunks,
   widgets,
   addWidget,
@@ -130,6 +132,10 @@ const DiffFile = ({
     );
   };
 
+  const BinaryMessage = () => {
+    return <Text p={2}>バイナリファイルが更新されました。</Text>;
+  };
+
   const DeleteMessage = () => {
     return (
       <Text p={2}>
@@ -159,6 +165,8 @@ const DiffFile = ({
       </Heading>
       {type === "rename" ? (
         <RenameMessage />
+      ) : isBinary ? (
+        <BinaryMessage />
       ) : type === "delete" && !isVisibleDelete ? (
         <DeleteMessage />
       ) : lines >= 100 && !isVisibleLarge ? (

--- a/src/components/review/DiffFileList.tsx
+++ b/src/components/review/DiffFileList.tsx
@@ -20,7 +20,53 @@ type CustomProps = {
 type Props = StackProps & CustomProps;
 
 const DiffFileList = ({ diff, widgets, addWidget, ...props }: Props) => {
+  const parseBinary = (
+    diff: string
+  ): {
+    isBinary?: boolean;
+    type?: string;
+    oldPath?: string;
+    newPath?: string;
+  }[] => {
+    // trim(): 末尾の改行削除。2行下で lastLine を正しく取得するため
+    // "diff --git ..." の行がファイル境界
+    const files = diff.trim().split("\ndiff --git");
+    return files.map((file) => {
+      const lastLine = file.split("\n").slice(-1)[0];
+      const words = lastLine.split(" ");
+      const info: {
+        isBinary?: boolean;
+        type?: string;
+        oldPath?: string;
+        newPath?: string;
+      } = {};
+      if (words[0] === "Binary") {
+        info.isBinary = true;
+        const oldPath = words[2];
+        const newPath = words[4];
+        if (oldPath === "/dev/null") {
+          info.type = "add";
+          info.oldPath = oldPath;
+          info.newPath = newPath.slice(2);
+        } else if (newPath === "/dev/null") {
+          info.type = "delete";
+          info.oldPath = oldPath.slice(2);
+          info.newPath = newPath;
+        } else {
+          info.type = "modify";
+          info.oldPath = oldPath.slice(2);
+          info.newPath = newPath.slice(2);
+        }
+      }
+      return info;
+    });
+  };
+
   const files = parseDiff(diff);
+  const binaryFiles = parseBinary(diff);
+  for (let i = 0; i < files.length; i++) {
+    files[i] = { ...files[i], ...binaryFiles[i] };
+  }
 
   return (
     <VStack {...props}>

--- a/src/components/review/DiffFileList.tsx
+++ b/src/components/review/DiffFileList.tsx
@@ -65,7 +65,15 @@ const DiffFileList = ({ diff, widgets, addWidget, ...props }: Props) => {
   const files = parseDiff(diff);
   const binaryFiles = parseBinary(diff);
   for (let i = 0; i < files.length; i++) {
-    files[i] = { ...files[i], ...binaryFiles[i] };
+    // 通常ファイルのとき、ライブラリ側の実装では isBinary プロパティは false ではなく未定義のため isBinary: false を記述
+    //
+    // バイナリファイルの解析問題が解消
+    //   → files[i] = { isBinary: false, ...files[i] };
+    // isBinary プロパティの未定義問題が解消
+    //   → files[i] = { ...files[i], ...binaryFiles[i] };
+    // 両方の問題が解消
+    //   → for 文不要
+    files[i] = { isBinary: false, ...files[i], ...binaryFiles[i] };
   }
 
   return (

--- a/src/components/review/DiffFileList.tsx
+++ b/src/components/review/DiffFileList.tsx
@@ -79,13 +79,22 @@ const DiffFileList = ({ diff, widgets, addWidget, ...props }: Props) => {
   return (
     <VStack {...props}>
       {files.map(
-        ({ oldPath, newPath, oldRevision, newRevision, type, hunks }: any) => (
+        ({
+          oldPath,
+          newPath,
+          oldRevision,
+          newRevision,
+          type,
+          isBinary,
+          hunks,
+        }: any) => (
           <DiffFile
             key={oldRevision + "-" + newRevision}
             fileId={oldRevision + "-" + newRevision}
             oldPath={oldPath}
             newPath={newPath}
             type={type}
+            isBinary={isBinary}
             hunks={hunks}
             widgets={widgets}
             addWidget={addWidget}


### PR DESCRIPTION
## 🔨 Details of Changes
<!-- 変更内容について記載する -->
- 差分がバイナリファイルの場合、その旨を表示させる
- バイナリファイルの移動は、移動の方のメッセージを表示
- 追加・削除・編集いずれも「バイナリファイルが更新されました。」と表示

## ✅ Resolved Issues
<!-- 解決する Issues を記載する -->
- close #120 

## 補足

### 表示されるメッセージに関して
とりあえずそれっぽいの書いてみたけど、提案あればぜひお願いします

### レビューしたいけど、バイナリファイルの差分を含むプルリクどれやねん
( ´･ω･)⊃ #172 
```
/git-baboo/easy-review/172/review
```

このプルリクは追加やけど、`dummy-pr` に移動や削除のプルリクも作ってます
(レビュワー指定してないので URL 直打ちで)