### PR TITLE
props に渡す String 型の値のフォーマットを ESLint で検知できるようにする

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
         "newlines-between": "always"
       }
     ],
+    "react/jsx-curly-brace-presence": "error",
     "react-hooks/exhaustive-deps": "off",
     "@next/next/no-document-import-in-page": "off"
   }

--- a/src/pages/[owner]/[repo]/[pullNumber]/review.tsx
+++ b/src/pages/[owner]/[repo]/[pullNumber]/review.tsx
@@ -173,7 +173,7 @@ const ReviewPage = () => {
   return (
     <>
       <Layout
-        text={"テンプレートを使ってレビューをしてみよう！"}
+        text="テンプレートを使ってレビューをしてみよう！"
         icon={BsFillChatDotsFill}
       >
         <Container py={9} maxW="container.lg">


### PR DESCRIPTION
## 🔨 変更内容

- props に渡す String 型の値のフォーマットを ESLint で検知できるようにする
  - ESLint にて `"react/jsx-curly-brace-presence": "error"` を追加
- １箇所見つかった違反の修正を含んでいます

## 注意点

Issue では props の文字列が対象やったけど、この指定では children の文字列なども検査対象に含まれています
props のみを対象として children は無視するなどの個別設定も可能です
まとめて含めちゃっていいかなって判断してこうしたけど、意見あればお願いします

参考：https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md

## ✅ 解決するイシュー

- close #209 